### PR TITLE
Fix: Edit Vegetation Threshold Upper and Lower display name and description

### DIFF
--- a/todeploy/VegetationChange.ipynb
+++ b/todeploy/VegetationChange.ipynb
@@ -181,10 +181,10 @@
     "#parameter display_name=\"Water Threshold\" description=\"The value for how strict the water masking should be, ranging from 0 for always land and 1 for always water.\" datatype=\"float\" options=[0,1]\n",
     "waterThresh = 0.4\n",
     "\n",
-    "#parameter display_name=\"Vegetation Threshold Upper\" description=\"Determines upper threshold for vegetation mask, typical values, for NDVI -0.7, typical for evi -1.75, typical for FC -70\" datatype=\"float\" options=[-100,100]\n",
+    "#parameter display_name=\"Vegetation Threshold Lower\" description=\"Determines lower threshold for vegetation mask, typical values, for NDVI -0.7, typical for evi -1.75, typical for FC -70\" datatype=\"float\" options=[-100,100]\n",
     "minC = -0.7\n",
     "\n",
-    "#parameter display_name=\"Vegetation Threshold Lower\" description=\"Determines upper threshold for vegetation mask, typical values, for NDVI 0.2, typical for evi 0.5, typical for FC -20\" datatype=\"float\" options=[-100,100]\n",
+    "#parameter display_name=\"Vegetation Threshold Upper\" description=\"Determines upper threshold for vegetation mask, typical values, for NDVI 0.2, typical for evi 0.5, typical for FC -20\" datatype=\"float\" options=[-100,100]\n",
     "maxC = -0.2"
    ]
   },


### PR DESCRIPTION
Changed the display_name for 'Vegetation Threshold Upper' to  'Vegetation Threshold Lower'.
Changed the display_name for 'Vegetation Threshold Lower' to  'Vegetation Threshold Upper'.